### PR TITLE
Reduce randomness and some overhead from benchmarks and add one for a…

### DIFF
--- a/example/build.gradle
+++ b/example/build.gradle
@@ -13,5 +13,7 @@ jmh {
     fork = 2
     iterations = 10
     warmupIterations = 10
+    timeOnIteration = '1s'
+    warmup = '1s'
     zip64 = true
 }

--- a/example/src/jmh/java/com/github/imasahiro/stringformatter/processor/benchmark/AllTypesBench.java
+++ b/example/src/jmh/java/com/github/imasahiro/stringformatter/processor/benchmark/AllTypesBench.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2016 Masahiro Ide
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.imasahiro.stringformatter.processor.benchmark;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.infra.Blackhole;
+
+public class AllTypesBench {
+    private static final AllTypesBenchFormatter.Formatter formatter =
+            new AllTypesBenchFormatter_Formatter();
+
+    private static String javaStringFormat(
+            String formatString, boolean b, char c, double d, float f, int i, long lng,
+            Object obj, String str) {
+        return String.format(formatString, b, c, d, f, i, lng, obj, str);
+    }
+
+    private static final boolean[] BOOLEAN = new boolean[] { false };
+    private static final char[] CHAR = new char[] { 'f' };
+    private static final double[] DOUBLE = new double[] { 1.3424 };
+    private static final float[] FLOAT = new float[] { 1424.1424f };
+    private static final int[] INT = new int[] { 34234234 };
+    private static final long[] LONG = new long[] { 324249243L };
+    private static final Object[] OBJ = new Object[] { new Object() };
+    private static final String[] STR = new String[] { "foobar" };
+
+    @Benchmark
+    public void javaStringFormat(Blackhole blackhole) {
+        blackhole.consume(javaStringFormat(
+                AllTypesBenchFormatter.FORMAT,
+                BOOLEAN[0], CHAR[0], DOUBLE[0], FLOAT[0], INT[0], LONG[0], OBJ[0], STR[0]));
+    }
+
+    private static String javaStringConcat(boolean b, char c, double d, float f, int i, long lng,
+                                           Object obj, String str) {
+        return "Benchmark - " + b + ' ' + c + ' ' + d + ' ' + f + ' ' + i + ' ' + lng + ' ' + obj + ' ' + str;
+    }
+
+    @Benchmark
+    public void javaStringConcat(Blackhole blackhole) {
+        blackhole.consume(javaStringConcat(
+                BOOLEAN[0], CHAR[0], DOUBLE[0], FLOAT[0], INT[0], LONG[0], OBJ[0], STR[0]));
+    }
+
+    private static String stringBuilder(boolean b, char c, double d, float f, int i, long lng,
+                                        Object obj, String str) {
+        return new StringBuilder()
+                .append(b)
+                .append(' ')
+                .append(c)
+                .append(' ')
+                .append(d)
+                .append(' ')
+                .append(f)
+                .append(' ')
+                .append(i)
+                .append(' ')
+                .append(lng)
+                .append(' ')
+                .append(obj)
+                .append(' ')
+                .append(str)
+                .toString();
+    }
+
+    @Benchmark
+    public void stringBuilder(Blackhole blackhole) {
+        blackhole.consume(stringBuilder(
+                BOOLEAN[0], CHAR[0], DOUBLE[0], FLOAT[0], INT[0], LONG[0], OBJ[0], STR[0]));
+    }
+
+    @Benchmark
+    public void autoStringFormatter(Blackhole blackhole) {
+        blackhole.consume(formatter.format(
+                BOOLEAN[0], CHAR[0], DOUBLE[0], FLOAT[0], INT[0], LONG[0], OBJ[0], STR[0]));
+    }
+}

--- a/example/src/jmh/java/com/github/imasahiro/stringformatter/processor/benchmark/CapacityBench.java
+++ b/example/src/jmh/java/com/github/imasahiro/stringformatter/processor/benchmark/CapacityBench.java
@@ -16,47 +16,47 @@
 
 package com.github.imasahiro.stringformatter.processor.benchmark;
 
-import java.util.concurrent.ThreadLocalRandom;
-import java.util.function.Supplier;
-
 import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.infra.Blackhole;
 
+@State(Scope.Benchmark)
 public class CapacityBench {
     private static final CapacityBenchFormatter.Formatter formatter = new CapacityBenchFormatter_Formatter();
     private static final CapacityBenchFormatter.FormatterWithCapacity formatterWithCapacity
             = new CapacityBenchFormatter_FormatterWithCapacity();
 
-    private static final Supplier<Integer> integerSupplier = () -> ThreadLocalRandom.current().nextInt();
+    private static final int[] VALUES = new int[] { 1, 10000000, -10000000, 555, 19032313, 14142, 0 };
 
     @Benchmark
     public void javaStringFormat(Blackhole blackhole) {
         blackhole.consume(String.format(CapacityBenchFormatter.FORMAT,
-                                        integerSupplier.get(),
-                                        integerSupplier.get(),
-                                        integerSupplier.get(),
-                                        integerSupplier.get(),
-                                        integerSupplier.get(),
-                                        integerSupplier.get()));
+                                        VALUES[0],
+                                        VALUES[1],
+                                        VALUES[2],
+                                        VALUES[3],
+                                        VALUES[4],
+                                        VALUES[5]));
     }
 
     @Benchmark
     public void autoStringFormatter(Blackhole blackhole) {
-        blackhole.consume(formatter.format(integerSupplier.get(),
-                                           integerSupplier.get(),
-                                           integerSupplier.get(),
-                                           integerSupplier.get(),
-                                           integerSupplier.get(),
-                                           integerSupplier.get()));
+        blackhole.consume(formatter.format(VALUES[0],
+                                           VALUES[1],
+                                           VALUES[2],
+                                           VALUES[3],
+                                           VALUES[4],
+                                           VALUES[5]));
     }
 
     @Benchmark
     public void autoStringFormatterCapacity(Blackhole blackhole) {
-        blackhole.consume(formatterWithCapacity.format(integerSupplier.get(),
-                                                       integerSupplier.get(),
-                                                       integerSupplier.get(),
-                                                       integerSupplier.get(),
-                                                       integerSupplier.get(),
-                                                       integerSupplier.get()));
+        blackhole.consume(formatterWithCapacity.format(VALUES[0],
+                                                       VALUES[1],
+                                                       VALUES[2],
+                                                       VALUES[3],
+                                                       VALUES[4],
+                                                       VALUES[5]));
     }
 }

--- a/example/src/jmh/java/com/github/imasahiro/stringformatter/processor/benchmark/IntegerStringifyBench.java
+++ b/example/src/jmh/java/com/github/imasahiro/stringformatter/processor/benchmark/IntegerStringifyBench.java
@@ -16,48 +16,38 @@
 
 package com.github.imasahiro.stringformatter.processor.benchmark;
 
-import java.util.concurrent.ThreadLocalRandom;
-import java.util.function.Supplier;
-
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.infra.Blackhole;
 
 public class IntegerStringifyBench {
     private static final IntegerStringifyBenchFormatter.Formatter formatter =
             new IntegerStringifyBenchFormatter_Formatter();
-    private static final Supplier<Integer> integerSupplier = () -> ThreadLocalRandom.current().nextInt();
 
     private static String javaStringFormat(String formatString, int a, int b, int c, int d) {
         return String.format(formatString, a, b, c, d);
     }
 
+    private static final int[] VALUES = new int[] { 1, 10000000, -10000000, 5555 };
+
     @Benchmark
     public void javaStringFormat(Blackhole blackhole) {
         blackhole.consume(javaStringFormat(IntegerStringifyBenchFormatter.FORMAT,
-                                           integerSupplier.get(),
-                                           integerSupplier.get(),
-                                           integerSupplier.get(),
-                                           integerSupplier.get()));
+                                           VALUES[0],
+                                           VALUES[1],
+                                           VALUES[2],
+                                           VALUES[3]));
     }
 
     private static String javaStringConcat(int a, int b, int c, int d) {
-        String s = "";
-        s += a;
-        s += " + ";
-        s += b;
-        s += " * ";
-        s += c;
-        s += " = ";
-        s += d;
-        return s;
+        return a + " + " + b + " * " + c + " = " + d;
     }
 
     @Benchmark
     public void javaStringConcat(Blackhole blackhole) {
-        blackhole.consume(javaStringConcat(integerSupplier.get(),
-                                           integerSupplier.get(),
-                                           integerSupplier.get(),
-                                           integerSupplier.get()));
+        blackhole.consume(javaStringConcat(VALUES[0],
+                                           VALUES[1],
+                                           VALUES[2],
+                                           VALUES[3]));
     }
 
     private static String stringBuilder(int a, int b, int c, int d) {
@@ -74,17 +64,17 @@ public class IntegerStringifyBench {
 
     @Benchmark
     public void stringBuilder(Blackhole blackhole) {
-        blackhole.consume(stringBuilder(integerSupplier.get(),
-                                        integerSupplier.get(),
-                                        integerSupplier.get(),
-                                        integerSupplier.get()));
+        blackhole.consume(stringBuilder(VALUES[0],
+                                        VALUES[1],
+                                        VALUES[2],
+                                        VALUES[3]));
     }
 
     @Benchmark
     public void autoStringFormatter(Blackhole blackhole) {
-        blackhole.consume(formatter.format(integerSupplier.get(),
-                                           integerSupplier.get(),
-                                           integerSupplier.get(),
-                                           integerSupplier.get()));
+        blackhole.consume(formatter.format(VALUES[0],
+                                           VALUES[1],
+                                           VALUES[2],
+                                           VALUES[3]));
     }
 }

--- a/example/src/jmh/java/com/github/imasahiro/stringformatter/processor/benchmark/StringBench.java
+++ b/example/src/jmh/java/com/github/imasahiro/stringformatter/processor/benchmark/StringBench.java
@@ -16,16 +16,14 @@
 
 package com.github.imasahiro.stringformatter.processor.benchmark;
 
-import java.util.concurrent.ThreadLocalRandom;
-import java.util.function.Supplier;
-
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.infra.Blackhole;
 
 public class StringBench {
 
     private static final StringBenchFormatter.Formatter formatter = new StringBenchFormatter_Formatter();
-    private static final Supplier<Integer> integerSupplier = () -> ThreadLocalRandom.current().nextInt();
+
+    private static final int[] VALUES = new int[] { 1, 100000000 };
 
     private static String javaStringFormat(String formatString, int i, int j) {
         return String.format(formatString, i, j);
@@ -34,22 +32,18 @@ public class StringBench {
     @Benchmark
     public void javaStringFormat(Blackhole blackhole) {
         blackhole.consume(javaStringFormat(StringBenchFormatter.FORMAT,
-                                           integerSupplier.get(),
-                                           integerSupplier.get()));
+                                           VALUES[0],
+                                           VALUES[1]));
     }
 
     private static String javaStringConcat(int i, int j) {
-        String s = "Hi ";
-        s += i;
-        s += "; Hi to you ";
-        s += j;
-        return s;
+        return "Hi " + i + "; Hi to you " + j;
     }
 
     @Benchmark
     public void javaStringConcat(Blackhole blackhole) {
-        blackhole.consume(javaStringConcat(integerSupplier.get(),
-                                           integerSupplier.get()));
+        blackhole.consume(javaStringConcat(VALUES[0],
+                                           VALUES[1]));
     }
 
     private static String stringBuilder(int i, int j) {
@@ -62,13 +56,13 @@ public class StringBench {
 
     @Benchmark
     public void stringBuilder(Blackhole blackhole) {
-        blackhole.consume(stringBuilder(integerSupplier.get(),
-                                        integerSupplier.get()));
+        blackhole.consume(stringBuilder(VALUES[0],
+                                        VALUES[1]));
     }
 
     @Benchmark
     public void autoStringFormatter(Blackhole blackhole) {
-        blackhole.consume(formatter.format(integerSupplier.get(),
-                                           integerSupplier.get()));
+        blackhole.consume(formatter.format(VALUES[0],
+                                           VALUES[1]));
     }
 }

--- a/example/src/main/java/com/github/imasahiro/stringformatter/processor/benchmark/AllTypesBenchFormatter.java
+++ b/example/src/main/java/com/github/imasahiro/stringformatter/processor/benchmark/AllTypesBenchFormatter.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2016 Masahiro Ide
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.imasahiro.stringformatter.processor.benchmark;
+
+import com.github.imasahiro.stringformatter.annotation.AutoStringFormatter;
+import com.github.imasahiro.stringformatter.annotation.Format;
+
+/**
+ * Formatter definition for integer to string formatting.
+ */
+public final class AllTypesBenchFormatter {
+    public static final String FORMAT = "Benchmark - %s %s %s %s %s %s %s %s";
+
+    private AllTypesBenchFormatter() {}
+
+    @AutoStringFormatter
+    interface Formatter {
+        @Format(FORMAT)
+        String format(
+                boolean b, char c, double d, float f, int i, long lng, Object obj, String str);
+    }
+}


### PR DESCRIPTION
…ll types.

I remembered this project from your blog post and want to try using it. I noticed some low-hanging fruit in the implementation and want to look into some optimizations. For now, updated the benchmarks so they are easier to understand.

- No `Random` since it makes timing across runs hard to compare. Constant folding can be avoided by just making sure values are in an array. Also removes unpredictable unboxing / boxing
- Does not concat using a local variable. Java can't optimize string concatenation when there is a local variable. concat is supposed to always be fastest, and with the change it seems to be
- Reduces iteration time since its longer than needed
- Adds a benchmark with all types to have a representative one for all logic

`IntegerStringifyBench.autoStringFormatter` is much slower than it should be I think my computer might have had a stall during it... But otherwise, it shows that the processor should probably generate concatenation instead of `StringBuilder` - alternatively it could compute the correct initial capacity of the `StringBuilder`, but there's probably no point to reproduce that same logic that concatenate has.

```
Benchmark                                                               Mode  Cnt      Score     Error   Units
c.g.i.s.processor.benchmark.AllTypesBench.autoStringFormatter          thrpt   20   2059.914 ±  29.679  ops/ms
c.g.i.s.processor.benchmark.AllTypesBench.javaStringConcat             thrpt   20   2334.453 ±  19.358  ops/ms
c.g.i.s.processor.benchmark.AllTypesBench.javaStringFormat             thrpt   20    390.952 ±  11.982  ops/ms
c.g.i.s.processor.benchmark.AllTypesBench.stringBuilder                thrpt   20   2307.216 ±  28.409  ops/ms
c.g.i.s.processor.benchmark.CapacityBench.autoStringFormatter          thrpt   20   1838.333 ±  88.888  ops/ms
c.g.i.s.processor.benchmark.CapacityBench.autoStringFormatterCapacity  thrpt   20   1660.954 ± 352.365  ops/ms
c.g.i.s.processor.benchmark.CapacityBench.javaStringFormat             thrpt   20    233.128 ±   6.989  ops/ms
c.g.i.s.processor.benchmark.IntegerStringifyBench.autoStringFormatter  thrpt   20   6822.465 ± 845.009  ops/ms
c.g.i.s.processor.benchmark.IntegerStringifyBench.javaStringConcat     thrpt   20  13212.559 ± 167.060  ops/ms
c.g.i.s.processor.benchmark.IntegerStringifyBench.javaStringFormat     thrpt   20    615.420 ±  49.227  ops/ms
c.g.i.s.processor.benchmark.IntegerStringifyBench.stringBuilder        thrpt   20  14399.826 ± 303.416  ops/ms
c.g.i.s.processor.benchmark.StringBench.autoStringFormatter            thrpt   20  10382.736 ± 114.277  ops/ms
c.g.i.s.processor.benchmark.StringBench.javaStringConcat               thrpt   20  25570.515 ± 396.390  ops/ms
c.g.i.s.processor.benchmark.StringBench.javaStringFormat               thrpt   20   1271.392 ±  67.021  ops/ms
c.g.i.s.processor.benchmark.StringBench.stringBuilder                  thrpt   20  13988.031 ± 249.054  ops/ms
c.g.i.s.runtime.benchmark.IntegerUtilsBench.array                      thrpt   20  20617.764 ± 132.039  ops/ms
c.g.i.s.runtime.benchmark.IntegerUtilsBench.loop                       thrpt   20  21831.980 ± 267.584  ops/ms
```